### PR TITLE
Remove include dir from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 * text=auto eol=lf
 *.mdx linguist-vendored
 *.css linguist-vendored
+include/* linguist-vendored


### PR DESCRIPTION
The language stats currently also includes the `Include` directory, which pollutes the language stats with `lua` lines. This PR adds it to the exclusion list to ensure it's excluded.