### PR TITLE
Fix `checkRightMissing`

### DIFF
--- a/.changeset/empty-hounds-taste.md
+++ b/.changeset/empty-hounds-taste.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/deep-equal": patch
+---
+
+Fixed an issue with checkRightMissing being disabled and right values not being properly checked

--- a/api/deep-equal.d.ts
+++ b/api/deep-equal.d.ts
@@ -294,18 +294,18 @@ export declare interface DeepEqualConfig {
      */
     readonly customCheckers?: CustomCheckerMap<CheckerType>;
     /**
-     * Check for missing values from the left in comparison to the right.
+     * Check for missing values from the right in comparison to the left.
      *
      * Only really applicable to arrays and objects.
      *
      * @remarks
      * When comparing two arrays, `checkRightMissing` will also check if there
-     * are any values missing from the left array that are present in the right
+     * are any values missing from the right array that are present in the left
      * array.
      *
      * When comparing two objects (non array tables), `checkRightMissing` will also check
-     * if there are any properties missing from the left object that are present
-     * in the right object.
+     * if there are any properties missing from the right object that are present
+     * in the left object.
      *
      * @defaultValue `true`
      *

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"api:build": "npm run build",
 		"api:extract": "api-extractor run --local --verbose",
 		"api:update": "npx run-s api:build api:extract",
-		"api": "npx api:update",
+		"api": "npm run api:update",
 		"format": "npx eslint --fix",
 		"lint": "npm run format",
 		"lock": "npm i --package-lock-only",

--- a/src/algorithm/deep-equal-nested.ts
+++ b/src/algorithm/deep-equal-nested.ts
@@ -128,8 +128,8 @@ export function deepEqualNested(
         });
       }
     } else {
-      const rightMissing = findMissingElements(config, path, left, right);
-      const leftMissing = config.checkRightMissing ? findMissingElements(config, path, right, left) : [];
+      const rightMissing = config.checkRightMissing ? findMissingElements(config, path, left, right) : [];
+      const leftMissing = findMissingElements(config, path, right, left);
 
       if (leftMissing.isEmpty() && rightMissing.isEmpty()) return Option.none();
 
@@ -169,13 +169,12 @@ export function deepEqualNested(
       }
     }
 
-    if (!config.checkRightMissing) return Option.none();
-
     const leftEntries = Object.entries(leftValue) as Array<[keyof object, unknown]>;
 
     for (const [key, value] of leftEntries) {
       const subPath = `${path}.${key}`;
       if (!(key in rightValue)) {
+        if (!config.checkRightMissing) continue;
         return Option.some({
           failType: FailureType.MISSING,
           leftValue: value,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -79,18 +79,18 @@ export interface DeepEqualConfig {
   readonly customCheckers?: CustomCheckerMap<CheckerType>;
 
   /**
-   * Check for missing values from the left in comparison to the right.
+   * Check for missing values from the right in comparison to the left.
    *
    * Only really applicable to arrays and objects.
    *
    * @remarks
    * When comparing two arrays, `checkRightMissing` will also check if there
-   * are any values missing from the left array that are present in the right
+   * are any values missing from the right array that are present in the left
    * array.
    *
    * When comparing two objects (non array tables), `checkRightMissing` will also check
-   * if there are any properties missing from the left object that are present
-   * in the right object.
+   * if there are any properties missing from the right object that are present
+   * in the left object.
    *
    * @defaultValue `true`
    *
@@ -225,17 +225,14 @@ export function getDefaultDeepEqualConfig(): Partial<DeepEqualConfig> {
  * @public
  */
 export function mergeConfigs(...configs: (Partial<DeepEqualConfig> | undefined)[]): Partial<DeepEqualConfig> {
-  return configs.filterUndefined().reduce(
-    (acc, curr) => ({
-      ...acc,
-      ...curr,
-      ignore: [...(acc?.ignore ?? []), ...(curr?.ignore ?? [])],
-      referenceOnly: [...(acc?.referenceOnly ?? []), ...(curr?.referenceOnly ?? [])],
-      customCheckers: {
-        ...acc?.customCheckers,
-        ...curr?.customCheckers,
-      },
-    }),
-    {} as Partial<DeepEqualConfig>
-  );
+  return configs.filterUndefined().reduce((acc, curr) => ({
+    ...acc,
+    ...curr,
+    ignore: [...(acc?.ignore ?? []), ...(curr?.ignore ?? [])],
+    referenceOnly: [...(acc?.referenceOnly ?? []), ...(curr?.referenceOnly ?? [])],
+    customCheckers: {
+      ...acc?.customCheckers,
+      ...curr?.customCheckers,
+    },
+  }));
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -380,19 +380,19 @@ export = () => {
     });
 
     describe("arrays", () => {
-      it("should pass on left missing", () => {
-        const result = deepEqual([1, 2], [1, 2, 3]);
+      it("should pass on right missing", () => {
+        const result = deepEqual([1, 2, 3], [1, 2]);
         expect(result).to.never.be.ok();
       });
 
-      it("should still fail on right missing", () => {
-        const result = deepEqual([1, 2, 3], [1, 2]);
+      it("should still fail on left missing", () => {
+        const result = deepEqual([1, 2], [1, 2, 3]);
         expect(result).to.be.ok();
         assert(result);
 
         expect(FailureType[result.failType]).to.equal("MISSING_ARRAY_VALUE");
-        expect(encode(result.rightMissing)).to.equal("[3]");
-        expect(result.leftMissing.isEmpty()).to.equal(true);
+        expect(encode(result.leftMissing)).to.equal("[3]");
+        expect(result.rightMissing.isEmpty()).to.equal(true);
       });
     });
 
@@ -433,6 +433,48 @@ export = () => {
         expect(result.rightValue).to.equal("Civic");
         expect(result.leftValue).to.equal(undefined);
         expect(result.path).to.equal("car");
+      });
+
+      it("should still fail on nested left missing", () => {
+        const result = deepEqual(
+          {
+            child: {
+              name: "daymon",
+            },
+            age: 100,
+          },
+          {
+            name: "daymon",
+          }
+        );
+
+        expect(result).to.be.ok();
+        assert(result);
+
+        expect(FailureType[result.failType]).to.equal("MISSING");
+        expect(result.rightValue).to.equal("daymon");
+        expect(result.leftValue).to.equal(undefined);
+        expect(result.path).to.equal("name");
+      });
+
+      it("should still fail on different values", () => {
+        const result = deepEqual(
+          {
+            name: "bryan",
+            age: 100,
+          },
+          {
+            name: "daymon",
+          }
+        );
+
+        expect(result).to.be.ok();
+        assert(result);
+
+        expect(FailureType[result.failType]).to.equal("DIFFERENT_VALUES");
+        expect(result.rightValue).to.equal("daymon");
+        expect(result.leftValue).to.equal("bryan");
+        expect(result.path).to.equal("name");
       });
     });
   });


### PR DESCRIPTION
`checkRightMissing` was exiting too early, and wouldn't check to ensure values between both were equal. This PR fixes that, as well as adds a test to catch it.

The docs also incorrectly described `checkRightMissing`, and the implementation for arrays was backwards. This also fixes that.